### PR TITLE
Fixed duplicate mails

### DIFF
--- a/swg/model/mail/SWGMailBox.java
+++ b/swg/model/mail/SWGMailBox.java
@@ -306,13 +306,13 @@ public final class SWGMailBox implements Serializable {
                             mail = newMail(tgt, owner);
 
                             if (mail.type() == Type.Auction)
-                                folderAuction.addInternal(mail);
+                                folderAuction.add(mail);
                             else if (mail.type() == Type.ISDroid)
-                                folderISDroid.addInternal(mail);
+                                folderISDroid.add(mail);
                             else if (mail.fromLine().equalsIgnoreCase(boxOwner))
-                                folderSent.addInternal(mail); // is CC to self
+                                folderSent.add(mail); // is CC to self
                             else
-                                folderInbox.addInternal(mail);
+                                folderInbox.add(mail);
 
                             allMails.put(fn, mail);
                         } catch (SecurityException e) {
@@ -418,9 +418,9 @@ public final class SWGMailBox implements Serializable {
                             && contains(mail.getName()) != null) continue;
 
                     if (mail.type() == Type.Auction)
-                        folderAuction.addInternal(mail);
+                        folderAuction.add(mail);
                     else if (mail.type() == Type.ISDroid)
-                        folderISDroid.addInternal(mail);
+                        folderISDroid.add(mail);
 
                     // some old suffixes, if any
                     else if (mail.type() == Type.Trash
@@ -428,9 +428,9 @@ public final class SWGMailBox implements Serializable {
                         folderTrash.addInternal(mail);
                     else if (mail.type() == Type.Sent
                             || fn.endsWith(SWGMailMessage.Type.Sent.suffix))
-                        folderSent.addInternal(mail);
+                        folderSent.add(mail);
                     else
-                        folderInbox.addInternal(mail);
+                        folderInbox.add(mail);
 
                     allMails.put(mail.getName(), mail);
                 } catch (Exception e) {


### PR DESCRIPTION
For some reason addInternal was being used everywhere which has zero validation, it just blindly adds mails to index regardless.
I changed them to use the add function which uses validation to prevent duplicates.
The Trash folder would be about the only folder I can think of that would not need any validation, thus I left the addInternal calls in place for Trash.