### PR TITLE
Duplicate mail fix and new character detection

### DIFF
--- a/swg/gui/SWGInitialize.java
+++ b/swg/gui/SWGInitialize.java
@@ -497,12 +497,18 @@ public final class SWGInitialize extends JPanel {
                 public void run() {
                     scanForMails(universe);
                     scanForMails(tc);
-                    if (SWGMailMessage.hasError)
+                    if (SWGMailMessage.hasError) {
                         JOptionPane.showMessageDialog(frame,
                                 "Problems reading some mails.\nSee the \"logs" +
                                         "\\mail-error.txt\" for details",
                                 "Error parsing mails",
                                 JOptionPane.ERROR_MESSAGE);
+					}
+					
+					scanForGalaxies(universe, 30, 35);
+					scanForGalaxies(tc, 35, 40);
+					scanForCharacters(universe, 40, 65);
+					scanForCharacters(tc, 65, 70);
 
                     frame.beginPostLaunchTasks();
                     exec.shutdown();

--- a/swg/model/mail/SWGMailBox.java
+++ b/swg/model/mail/SWGMailBox.java
@@ -391,7 +391,7 @@ public final class SWGMailBox implements Serializable {
                 if (m.getType() != Type.ISDroid) {
                     m.type(Type.Trash);
                     folderISDroid.remove(i);
-                    folderTrash.addInternal(m);
+                    folderTrash.add(m);
                 }
             }
         }
@@ -425,7 +425,7 @@ public final class SWGMailBox implements Serializable {
                     // some old suffixes, if any
                     else if (mail.type() == Type.Trash
                             || fn.endsWith(SWGMailMessage.Type.Trash.suffix))
-                        folderTrash.addInternal(mail);
+                        folderTrash.add(mail);
                     else if (mail.type() == Type.Sent
                             || fn.endsWith(SWGMailMessage.Type.Sent.suffix))
                         folderSent.add(mail);

--- a/swg/model/mail/SWGMailBox.java
+++ b/swg/model/mail/SWGMailBox.java
@@ -306,13 +306,13 @@ public final class SWGMailBox implements Serializable {
                             mail = newMail(tgt, owner);
 
                             if (mail.type() == Type.Auction)
-                                folderAuction.addInternal(mail);
+                                folderAuction.add(mail);
                             else if (mail.type() == Type.ISDroid)
-                                folderISDroid.addInternal(mail);
+                                folderISDroid.add(mail);
                             else if (mail.fromLine().equalsIgnoreCase(boxOwner))
-                                folderSent.addInternal(mail); // is CC to self
+                                folderSent.add(mail); // is CC to self
                             else
-                                folderInbox.addInternal(mail);
+                                folderInbox.add(mail);
 
                             allMails.put(fn, mail);
                         } catch (SecurityException e) {
@@ -418,9 +418,9 @@ public final class SWGMailBox implements Serializable {
                             && contains(mail.getName()) != null) continue;
 
                     if (mail.type() == Type.Auction)
-                        folderAuction.addInternal(mail);
+                        folderAuction.add(mail);
                     else if (mail.type() == Type.ISDroid)
-                        folderISDroid.addInternal(mail);
+                        folderISDroid.add(mail);
 
                     // some old suffixes, if any
                     else if (mail.type() == Type.Trash
@@ -428,9 +428,9 @@ public final class SWGMailBox implements Serializable {
                         folderTrash.addInternal(mail);
                     else if (mail.type() == Type.Sent
                             || fn.endsWith(SWGMailMessage.Type.Sent.suffix))
-                        folderSent.addInternal(mail);
+                        folderSent.add(mail);
                     else
-                        folderInbox.addInternal(mail);
+                        folderInbox.add(mail);
 
                     allMails.put(mail.getName(), mail);
                 } catch (Exception e) {


### PR DESCRIPTION
* Previously characters were only detected during setup. Now new characters are scanned for during every launch.
* The mail scanner was adding every mail file it found regardless if it existed in the DAT upon every launch (and subsequently saving it on exit) which was throwing off trade stats. This is now fixed.
